### PR TITLE
Fixing bugs in header logo and show three post columns

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,7 +2,7 @@
 // If you want to use different layouts for different pages, you can pass this information in the context of the pages you create, and then conditionally render in your layout file.
 // called after every page is created.
 
-const postsPerPage = 10;
+const postsPerPage = 9;
 
 const path = require("path")
 const _ = require("lodash")

--- a/src/components/card/card.module.scss
+++ b/src/components/card/card.module.scss
@@ -1,17 +1,17 @@
 @import "../../css/colors.scss";
 
-.list-node {
+.container {
+  width: 100%;
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
-  max-width: 22.4rem;
 }
 
 .styled-image {
   border-radius: 3%;
   margin-bottom: 1.5rem;
   width: 100%;
-  height: 15.3rem;
+  height: 15rem;
 
   @media screen and (max-width:50rem) {
     height: 8.125rem;
@@ -22,6 +22,7 @@
   text-decoration: none;
   color: $black;
   font-size: 1.875rem;
+  max-width: 100%;
 
   @media screen and (max-width:50rem) {
     font-size: 1.375rem;

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -7,14 +7,12 @@ import Category from "../category/category.tsx";
 import * as cardStyles from "./card.module.scss";
 
 const Card = ({ data }) => (
-  <article key={data.id}>
-    <div className={cardStyles.listNode}>
-      <img className={cardStyles.styledImage} src={data.frontmatter.thumbnail}/>
-      <Category data={data.frontmatter.category}/>
-      <Link className={cardStyles.styledLink} to={`/${_.kebabCase(data.frontmatter.permalink)}`}>
+  <article key={data.id} className={cardStyles.container}>
+    <img className={cardStyles.styledImage} src={data.frontmatter.thumbnail}/>
+    <Category data={data.frontmatter.category}/>
+    <Link className={cardStyles.styledLink} to={`/${_.kebabCase(data.frontmatter.permalink)}`}>
       {data.frontmatter.title}
-      </Link>
-    </div>
+    </Link>
   </article>
 );
 

--- a/src/elements/containers.js
+++ b/src/elements/containers.js
@@ -51,14 +51,10 @@ export const StyledContainerHeader = styled.div`
 `
 
 export const StyledContainerNavBarXL = styled.div`
-  /*position: fixed;*/
   display: flex;
   width: 100%;
   height: 95px;
   justify-content: center;
-  align-items: stretch;
-  background-color: #fff;
-  object-fit: fill;
   
   @media ${props => props.theme.breakpoints.tablet} {
   }

--- a/src/layouts/layout.js
+++ b/src/layouts/layout.js
@@ -11,13 +11,6 @@ import Footer from "../components/footer/footer.tsx";
 import { navMenu, navMenuItem, footerCol, desktopLogo } from '../layouts/layout.module.scss';
 import { StyledContainerHeader, StyledContainerNavBarXL } from "../elements";
 
-export const StyledMain = styled.main`
-  grid-column-start: 2;
-  grid-column-end: span 12;
-  grid-row-start: 2;
-  grid-row-end: span 1;
-`
-
 export const StyledGetStartedButton = styled.a`
   width: 147px;
   height: 44px;
@@ -34,6 +27,7 @@ export const StyledGetStartedTextButton = styled.div`
   font-size: 14px;
   font-weight: 700;
   letter-spacing: .5px;
+  max-height: 17px;
 `
 export const StyledFooterWrapper = styled.div`
   display: flex;
@@ -77,8 +71,8 @@ function Layout({children, pageContext}) {
               <StaticImage 
                 src="../../static/images/logo.svg"
                 alt=""
-                width={40}
-                height={40}
+                width={56}
+                height={56}
               />
             </Link>
             <NavMenu menuItems={menuElements} classNameItem={navMenuItem} />
@@ -90,9 +84,7 @@ function Layout({children, pageContext}) {
           </StyledGetStartedButton>
         </StyledContainerHeader>
       </StyledContainerNavBarXL>
-      <StyledMain>
-        {children}
-      </StyledMain>
+      {children}
       <Footer>
         <StyledFooterWrapper>
           <div className={ desktopLogo}>

--- a/src/templates/blog-list.js
+++ b/src/templates/blog-list.js
@@ -1,20 +1,17 @@
-import React from "react"
-import styled from "styled-components"
-import Card from "../components/card/card.tsx"
-import Pager from "../components/pager/pager.tsx"
+import React from "react";
 
-import { graphql, Link } from "gatsby"
+import styled from "styled-components";
 
-export const ListRow = styled.div`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  gap: 4.4rem;
-`
+import Card from "../components/card/card.tsx";
+import Pager from "../components/pager/pager.tsx";
+
+import { graphql } from "gatsby";
 
 export const ListContainer = styled.div`
-  justify-content: center;
-  margin: 0 18%;
+  margin: 0 10%;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(22.4rem, 1fr));  
+  gap: 6rem 7.4rem;
 
   @media ${props => props.theme.breakpoints.mobile} {
   margin: 0 1.5rem;
@@ -33,16 +30,14 @@ const BlogList = ({ pageContext, data }) => {
   return (
     <>
       <ListContainer>
-      <ListRow>
         {edges.map(({ node }) => <Card data={node}/> )}
-      </ListRow>
       </ListContainer>
       <Pager pageContext={pageContext}/>
     </>
-  )
-}
+  );
+};
 
-export default BlogList
+export default BlogList;
 
 export const blogListQuery = graphql`
   query blogListQuery($skip: Int!, $limit: Int!) {


### PR DESCRIPTION
## Ticket

* [Header is not displaying correctly](https://www.notion.so/xmartlabs/Header-is-not-displaying-correctly-ee57023c7dbf4ae6b0e32e342dd02050)
* [The home page is showing only two columns instead of three](https://www.notion.so/xmartlabs/The-home-page-is-showing-only-two-columns-instead-of-three-fd3a921f53d24e70b50b50aecc0cda73)

## Type of change

* [X] Fix
* [ ] Story
* [ ] Chore

## Description of the change
In this commit I fixed the two mentioned bugs, the first one is the Header Logo, which I changed its size, so, now it covers the whole container, and, about the other bug, I changed the styles and some containers, now, the page has three columns and nine posts. Also, I change the position of the button text, now it is centered. 

## Screenshot/Execution

![Captura desde 2022-12-01 10-48-12](https://user-images.githubusercontent.com/107500715/205069430-7e59b4ee-e757-43a7-9d0a-59c8391c6481.png)
![Captura desde 2022-12-01 10-47-23](https://user-images.githubusercontent.com/107500715/205069691-52d3a635-9eb8-42b0-b7c0-33fc74f9170f.png)

## Related PRs
https://github.com/xmartlabs/xl-blog/pull/18