### PR TITLE
Fixing home banner bug

### DIFF
--- a/blogs/2022-01-28-airflow-taskflow-a-must.md
+++ b/blogs/2022-01-28-airflow-taskflow-a-must.md
@@ -1,7 +1,7 @@
 ---
 title: 4 reasons why you should use Airflow's Taskflow API
 date: 2022-02-22
-tags: [ETL, Airflow, Taskflow]
+tags: [ETL, Taskflow]
 author: remer
 category: data-engineering
 thumbnail: images/taskflow/taskflow-blogpost.jpg

--- a/src/pages/{mdx.frontmatter__permalink}.js
+++ b/src/pages/{mdx.frontmatter__permalink}.js
@@ -32,6 +32,7 @@ const BlogPost = ({ data }) => {
 
     return () => {
       window.removeEventListener('scroll', handleScroll);
+      setState(BannerType.home);
     };
   }, []);
 


### PR DESCRIPTION
## Ticket

* [The header from the blog page persists when going back to the homepage](https://www.notion.so/xmartlabs/The-header-from-the-blog-page-persists-when-going-back-to-the-homepage-df9e892d50d64e18bc903d5cfb37146a)

## Type of change

* [X] Fix
* [ ] Story
* [ ] Chore

## Description of the change

When I went from the blog to the home, the banner of the blog persisted. I fixed it, now, you can go for the different pages and see the correct banner picture. 

## Screenshot/Execution

https://user-images.githubusercontent.com/107500715/217315829-a8d3ee6e-fec3-4e9d-a987-879dd3622921.mp4

## Related PRs
Links to the related PRs
