### PR TITLE
Index scroll

### DIFF
--- a/src/components/title-blog-index/title-blog-index.jsx
+++ b/src/components/title-blog-index/title-blog-index.jsx
@@ -45,7 +45,24 @@ const TitleBlogIndex = ({ data, refIndexTitles, disappearIndex }) => {
       const titles = findTitles(elementList);
       const activeTitle = titles.findLast((title) => title.getBoundingClientRect().top <= 500) || titles[0];
       setTitleOnView(activeTitle.textContent);
-      setSelectLink('');
+      setSelectLink('');      
+
+      if (titles[titles.length -2].textContent == activeTitle.textContent || titles[titles.length -1].textContent  == activeTitle.textContent) {
+        linksContainerRef.current.scrollTo({
+          top: 600,
+          behavior: 'smooth',
+        });
+
+        setIsTopArrow(false);
+        setIsBottomArrow(true);
+      } else {
+        linksContainerRef.current.scrollTo({
+          top: 0,
+          behavior: 'smooth',
+        });
+        setIsTopArrow(true);
+        setIsBottomArrow(false);
+      }
     }
   };
   
@@ -90,7 +107,7 @@ const TitleBlogIndex = ({ data, refIndexTitles, disappearIndex }) => {
           {data?.map((title) => 
             <a href={"#" + title.id} key={title.id} onClick={() => setSelectLink(title.id)}
               className={classnames(
-                { [styles.selectedLink]: title.id === selectLink || titleOnView === title.id},
+                {[styles.selectedLink]: title.id === selectLink || titleOnView === title.id},
                 styles.links
               )}
             >

--- a/src/components/title-blog-index/title-blog-index.jsx
+++ b/src/components/title-blog-index/title-blog-index.jsx
@@ -48,7 +48,7 @@ const TitleBlogIndex = ({ data, refIndexTitles, disappearIndex }) => {
       setSelectLink('');      
 
       if (titles.length > 8) {
-        if (titles[titles.length -2].textContent == activeTitle.textContent || titles[titles.length -1].textContent  == activeTitle.textContent) {
+        if (titles[titles.length -2].textContent === activeTitle.textContent || titles[titles.length -1].textContent === activeTitle.textContent) {
           linksContainerRef.current.scrollTo({
             top: 600,
             behavior: 'smooth',

--- a/src/components/title-blog-index/title-blog-index.jsx
+++ b/src/components/title-blog-index/title-blog-index.jsx
@@ -47,22 +47,24 @@ const TitleBlogIndex = ({ data, refIndexTitles, disappearIndex }) => {
       setTitleOnView(activeTitle.textContent);
       setSelectLink('');      
 
-      if (titles[titles.length -2].textContent == activeTitle.textContent || titles[titles.length -1].textContent  == activeTitle.textContent) {
-        linksContainerRef.current.scrollTo({
-          top: 600,
-          behavior: 'smooth',
-        });
-
-        setIsTopArrow(false);
-        setIsBottomArrow(true);
-      } else {
-        linksContainerRef.current.scrollTo({
-          top: 0,
-          behavior: 'smooth',
-        });
-        setIsTopArrow(true);
-        setIsBottomArrow(false);
-      }
+      if (titles.length > 8) {
+        if (titles[titles.length -2].textContent == activeTitle.textContent || titles[titles.length -1].textContent  == activeTitle.textContent) {
+          linksContainerRef.current.scrollTo({
+            top: 600,
+            behavior: 'smooth',
+          });
+  
+          setIsTopArrow(false);
+          setIsBottomArrow(true);
+        } else {
+          linksContainerRef.current.scrollTo({
+            top: 0,
+            behavior: 'smooth',
+          });
+          setIsTopArrow(true);
+          setIsBottomArrow(false);
+        }
+      } 
     }
   };
   


### PR DESCRIPTION
## Ticket

* [Title Index new functionality](https://www.notion.so/xmartlabs/Index-new-functionality-b3fc636297944fbdb5bf13f3799f2ff6?pvs=4)

## Type of change

* [ ] Fix
* [X] Story
* [ ] Chore

## Description of the change

If the user is at the end of the blog, the title index has to scroll down itself (when there is not enough space to see all the titles) and vice versa.

## Screenshot/Execution

https://github.com/xmartlabs/xl-blog/assets/107500715/22290d68-7a90-4aa1-9e0c-f2c928099757

## Related PRs
Links to the related PRs
