### PR TITLE
Force kebab-case for all permalinks

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -183,8 +183,9 @@ exports.createPages = async ({actions, graphql, reporter}) => {
     });
 
     posts.forEach(post => {
+      const permalink = _.kebabCase(post.node.frontmatter.permalink);
       createPage({
-        path: post.node.frontmatter.permalink.startsWith('/') ? `/blog${post.node.frontmatter.permalink}` : `/blog/${post.node.frontmatter.permalink}`,
+        path: permalink.startsWith('/') ? `/blog${permalink}` : `/blog/${permalink}`,
         component: `${postTemplate}?__contentFilePath=${post.node.internal.contentFilePath}`,
         context: {
           id: post.node.id,


### PR DESCRIPTION
## Ticket

* [AI Integration Blog not showing content](https://www.notion.so/xmartlabs/AI-Integration-Blog-not-showing-content-454e2f10ec0b47db94c1c24f0bb5184c?pvs=4)

## Type of change

* [x] Fix
* [ ] Story
* [ ] Chore

## Description of the change

The blog's markdown has uppercase characters in its permalink but links to it were formatted to kebab-case. All blogs' paths are now formatted to kebab-case to avoid this issue in the future.