### PR TITLE
Chore: Sync CMS and site categories

### DIFF
--- a/blogs/testinguy-2024-embracing-ai-without-fear.md
+++ b/blogs/testinguy-2024-embracing-ai-without-fear.md
@@ -4,7 +4,7 @@ subtitle: " "
 permalink: testing-uy-2024-ai
 featured: true
 date: 2024-05-03
-category: development
+category: qa
 thumbnail: /images/testinguy-2024-blog.png
 tags:
   - QA

--- a/content/categories.yaml
+++ b/content/categories.yaml
@@ -25,3 +25,6 @@
 - category: data-engineering
   display_name: Data Engineering
   url: /category/data-engineering
+- category: qa
+  display_name: QA
+  url: /category/qa

--- a/src/components/blog-list/blog-list.jsx
+++ b/src/components/blog-list/blog-list.jsx
@@ -13,8 +13,9 @@ const Categories = {
   development: "Development",
   "product-design": "Design",
   "machine-learning": "Machine\u00a0Learning",
-  blockchain: "Blockchain",
   "people-events": "People",
+  strategy: "Strategy",
+  qa: "QA",
 };
 
 export const BlogList = ({ pageContext, data, location: { pathname } }) => {

--- a/src/components/header-banner/header-banner.jsx
+++ b/src/components/header-banner/header-banner.jsx
@@ -13,9 +13,11 @@ const HeaderBanner = () => {
       <span>•</span>
       <span>Machine Learning</span>
       <span>•</span>
-      <span>Blockchain</span>
+      <span>Strategy</span>
       <span>•</span>
       <span>People</span>
+      <span>•</span>
+      <span>QA</span>
       <span>•</span>
     </>
   );

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -45,9 +45,8 @@ collections:
           - { label: "Design", value: "product-design" }
           - { label: "Development", value: "development" }
           - { label: "Machine Learning", value: "machine-learning" }
-          - { label: "Data Engineering", value: "data-engineering" }
-          - { label: "Mobile Development", value: "mobile-development" }
           - { label: "Strategy", value: "strategy" }
+          - { label: "QA", value: "qa" }
       - label: "Thumbnail Image"
         hint: "image ratio must be .... "
         name: "thumbnail"


### PR DESCRIPTION
## Ticket

* [Blog categories in the main page and CMS don’t coincide](https://www.notion.so/xmartlabs/d3c8ac93a680454aac567f9d5d22f5e0?v=9941f8b9915142b59ee747c46758ea34&p=0aa0327ef9474135801904aa3f081ec6&pm=c)

## Type of change

* [ ] Fix
* [ ] Story
* [X] Chore

## Description of the change

Sync CMS and site categories.

## Screenshot/Execution

![image](https://github.com/xmartlabs/xl-blog/assets/73088217/807aacae-4867-4ccf-b0fe-fa779bf8dbd7)

